### PR TITLE
associate teams to a repository

### DIFF
--- a/repositories/main.tf
+++ b/repositories/main.tf
@@ -6,6 +6,11 @@ module "repository-warthog_load_testing" {
     visibility = "public"
   }
 
+  github_teams_repository = [{
+    team_id    = "team-triage"
+    permission = "triage"
+  }]
+
 }
 
 module "repository-xk6-mongo" {

--- a/repositories/templates/github_repository.tf
+++ b/repositories/templates/github_repository.tf
@@ -7,6 +7,7 @@ locals {
 
 resource "github_repository" "repo" {
   name                   = local.github_repository.name
+  description            = local.github_repository.description
   archive_on_destroy     = local.github_repository.archive_on_destroy
   allow_auto_merge       = local.github_repository.allow_auto_merge
   allow_merge_commit     = local.github_repository.allow_merge_commit

--- a/repositories/templates/github_team_repository.tf
+++ b/repositories/templates/github_team_repository.tf
@@ -1,0 +1,7 @@
+resource "github_team_repository" "team" {
+  for_each = { for idx, obj in var.github_teams_repository : idx => obj }
+  depends_on = [ github_repository.repo ]
+  team_id    = each.value.team_id
+  repository = github_repository.repo.name
+  permission = each.value.permission
+}

--- a/repositories/templates/variables.tf
+++ b/repositories/templates/variables.tf
@@ -3,6 +3,7 @@
 variable "github_repository_defaults" {
   type = object({
     name                            = optional(string),
+    description                     = string
     archive_on_destroy              = bool,
     allow_auto_merge                = bool,
     allow_merge_commit              = bool,
@@ -31,6 +32,7 @@ variable "github_repository_defaults" {
 
   default = {
     archive_on_destroy              = true,
+    description                     = ""
     allow_auto_merge                = false,
     allow_merge_commit              = false,
     allow_rebase_merge              = true,
@@ -120,4 +122,15 @@ variable "github_project_column" {
   default = {
     names = []
   }
+}
+
+# github_teams_repository
+
+variable "github_teams_repository" {
+  type = list(object({
+    team_id    = string
+    permission = string
+  }))
+
+  default = []
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now is possible to associate a team with specific permissions on to a repository.

## Related Issue
https://github.com/onebeyond/org-infra/issues/30
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Only the modules with `github_teams_repository` defined on it will contain changes during the apply.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
